### PR TITLE
Added argument for setting Due on CheckItem

### DIFF
--- a/trello/cards.py
+++ b/trello/cards.py
@@ -100,8 +100,8 @@ class Cards(ApiBase):
         resp = requests.put(f"https://trello.com/1/cards/{card_id_or_shortlink}/checklist/{idChecklistCurrent}/checkItem/{idCheckItem}", params={"key": self._apikey, "token": self._token}, data={"name": name, "state": state, "idChecklist": idChecklist, "pos": pos})
         return self.raise_or_json(resp)
 
-    def update_checkItem_idCheckItem(self, idCheckItem, card_id_or_shortlink, name=None, state=None, idChecklist=None, pos=None):
-        resp = requests.put(f"https://trello.com/1/cards/{card_id_or_shortlink}/checkItem/{idCheckItem}", params={"key": self._apikey, "token": self._token}, data={"name": name, "state": state, "idChecklist": idChecklist, "pos": pos})
+    def update_checkItem_idCheckItem(self, idCheckItem, card_id_or_shortlink, name=None, state=None, idChecklist=None, pos=None, due=None):
+        resp = requests.put(f"https://trello.com/1/cards/{card_id_or_shortlink}/checkItem/{idCheckItem}", params={"key": self._apikey, "token": self._token}, data={"name": name, "state": state, "idChecklist": idChecklist, "pos": pos, "due": due})
         return self.raise_or_json(resp)
 
     def update_closed(self, card_id_or_shortlink, value):
@@ -164,8 +164,8 @@ class Cards(ApiBase):
         resp = requests.post(f"https://trello.com/1/cards/{card_id_or_shortlink}/attachments", params={"key": self._apikey, "token": self._token}, data={"file": file, "url": url, "name": name, "mimeType": mimeType})
         return self.raise_or_json(resp)
 
-    def new_checklist_checkItem_idChecklist(self, idChecklist, card_id_or_shortlink, name, pos=None):
-        resp = requests.post(f"https://trello.com/1/cards/{card_id_or_shortlink}/checklist/{idChecklist}/checkItem", params={"key": self._apikey, "token": self._token}, data={"name": name, "pos": pos})
+    def new_checklist_checkItem_idChecklist(self, idChecklist, card_id_or_shortlink, name, pos=None, due=None):
+        resp = requests.post(f"https://trello.com/1/cards/{card_id_or_shortlink}/checklist/{idChecklist}/checkItem", params={"key": self._apikey, "token": self._token}, data={"name": name, "pos": pos, "due": due})
         return self.raise_or_json(resp)
 
     def new_checklist_checkItem_convertToCard_idChecklist_idCheckItem(self, idChecklist, idCheckItem, card_id_or_shortlink):

--- a/trello/checklists.py
+++ b/trello/checklists.py
@@ -56,8 +56,8 @@ class Checklists(ApiBase):
         resp = requests.post("https://trello.com/1/checklists", params={"key": self._apikey, "token": self._token}, data={"idCard": idCard, "name": name, "pos": pos, "idChecklistSource": idChecklistSource})
         return self.raise_or_json(resp)
 
-    def new_checkItem(self, idChecklist, name, pos=None, checked=None):
-        resp = requests.post(f"https://trello.com/1/checklists/{idChecklist}/checkItems", params={"key": self._apikey, "token": self._token}, data={"name": name, "pos": pos, "checked": checked})
+    def new_checkItem(self, idChecklist, name, pos=None, checked=None, due=None):
+        resp = requests.post(f"https://trello.com/1/checklists/{idChecklist}/checkItems", params={"key": self._apikey, "token": self._token}, data={"name": name, "pos": pos, "checked": checked, "due": due})
         return self.raise_or_json(resp)
 
     def delete(self, idChecklist):


### PR DESCRIPTION
With Trello's feature "Advanced checklists" the user have the possibility to add due dates to CheckItems (when Business Class or Enterprise)

https://help.trello.com/article/942-how-to-use-advanced-checklists-to-set-due-dates-and-add-members-to-checklist-items


This now adds the required argument to existing POST and PUT methods for CheckItems